### PR TITLE
feat: add installation guide to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# Installation
+
+[lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+{
+    "IlyasYOY/theme.nvim",
+    dependencies = "tjdevries/colorbuddy.nvim",
+    lazy = false,
+    priority = 1000,
+    config = function()
+        vim.cmd.colorscheme("ilyasyoy")
+    end,
+},
+```
+
 # theme.nvim
 
 Neovim Theme convenient for me.


### PR DESCRIPTION
Привет! В этом PR я:  
- Добавил блок с кодом для установки в `README.md`.  
- Указал зависимость `tjdevries/colorbuddy.nvim`, без которой цветовая схема не применяется.  
- Реализовал включение цветовой схемы сразу после загрузки плагина (при необходимости можно вынести и вызвать отдельно через `vim.cmd.colorscheme`).
